### PR TITLE
Using GET makes tries bookmarkable and easier to share.

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,16 +45,19 @@ def run_docopt(doc, argv):
     return result
 
 
-@app.route('/', methods=['GET', 'POST'])
+@app.route('/', methods=['GET'])
 def hello():
-    if request.method == 'POST':
-        args = run_docopt(request.form['doc'], request.form['argv'])
-        return render('index.html', args=args,
-                      doc=request.form['doc'],
-                      argv=request.form['argv'])
+    if 'doc' in request.args and 'argv' in request.args:
+        doc = request.args['doc']
+        argv = request.args['argv']
+        args = run_docopt(request.args['doc'], request.args['argv'])
     else:
-        return render('index.html', doc=__doc__,
-                                    argv='ship Guardian move 10 50 --speed=20')
+        doc = __doc__
+        argv = 'ship Guardian move 10 50 --speed=20'
+        args = ''
+    return render('index.html', args=args,
+                      doc=doc,
+                      argv=argv)
 
 
 if __name__ == '__main__':

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
     <h1>docopt</h1>
     <h2>Try</h2>
     <pre>docopt 0.5.0 (Python reference implementation); output: JSON</pre>
-    <form action="/" method=post>
+    <form action="/" method=get>
         <textarea name=doc rows=18 >{{ doc }}</textarea>
         <!--p><textarea id=term readonly>{{ args }}</textarea></p>
         <script type="text/javascript" >


### PR DESCRIPTION
I want to use try.docopt.org in an online discussion about a CLI.

This makes examples easier to share.

And using POST was unnecessary:
- there's no server state, so requests are always _safe_
- every request with the same `doc` and `argv` should render the same response (unless after the event of a major docopt update), which makes them _idempotent_.

GET fits nicely.
