### PR TITLE
Use shlex to tokenize the input string. Fixes #3

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ Options:
   --drifting    Drifting mine.
 
 """
-import os, sys, traceback, json
+import os, sys, traceback, json, shlex
 from StringIO import StringIO
 
 from flask import Flask, render_template as render, request
@@ -27,6 +27,10 @@ app = Flask(__name__)
 
 
 def run_docopt(doc, argv):
+    try:
+        argv = shlex.split(argv)
+    except ValueError:
+        pass
     real_stdout, sys.stdout = sys.stdout, StringIO()
     real_stderr, sys.stderr = sys.stderr, StringIO()
     try:


### PR DESCRIPTION
Allow the use of quoted arguments, e.g.

```
Usage:
  test <arg1> <arg2>
```

with the input `a "b c d"`

If tokenization fails, fall back to the original behaviour
